### PR TITLE
Define and use printf format macros for DWORD and ULONG.

### DIFF
--- a/loader/windows/icd_windows.c
+++ b/loader/windows/icd_windows.c
@@ -151,7 +151,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
             DWORD dwValueSize = sizeof(dwValue);
 
             // read the value name
-            KHR_ICD_TRACE("Reading value %lu...\n", dwIndex);
+            KHR_ICD_TRACE("Reading value %"PRIuDW"...\n", dwIndex);
             result = RegEnumValueA(
                   platformsKey,
                   dwIndex,
@@ -164,7 +164,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
             // if RegEnumKeyEx fails, we are done with the enumeration
             if (ERROR_SUCCESS != result)
             {
-                KHR_ICD_TRACE("Failed to read value %lu, done reading key.\n", dwIndex);
+                KHR_ICD_TRACE("Failed to read value %"PRIuDW", done reading key.\n", dwIndex);
                 break;
             }
             KHR_ICD_TRACE("Value %s found...\n", cszLibraryName);

--- a/loader/windows/icd_windows.h
+++ b/loader/windows/icd_windows.h
@@ -19,6 +19,18 @@
 #include <stdbool.h>
 #include <windows.h>
 
+#ifdef _LP64
+#define PRIDW_PREFIX
+#define PRIUL_PREFIX
+#else
+#define PRIDW_PREFIX "l"
+#define PRIUL_PREFIX "l"
+#endif
+#define PRIuDW PRIDW_PREFIX "u"
+#define PRIxDW PRIDW_PREFIX "x"
+#define PRIuUL PRIUL_PREFIX "u"
+#define PRIxUL PRIUL_PREFIX "x"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/loader/windows/icd_windows_hkr.c
+++ b/loader/windows/icd_windows_hkr.c
@@ -90,7 +90,7 @@ static bool ReadOpenCLKey(DEVINST dnDevNode)
 
     if (CR_SUCCESS != ret)
     {
-        KHR_ICD_TRACE("Failed with ret 0x%lx\n", ret);
+        KHR_ICD_TRACE("Failed with ret 0x%"PRIxDW"\n", ret);
         goto out;
     }
     else
@@ -105,14 +105,14 @@ static bool ReadOpenCLKey(DEVINST dnDevNode)
 
         if (ERROR_SUCCESS != result)
         {
-            KHR_ICD_TRACE("Failed to open sub key 0x%lx\n", result);
+            KHR_ICD_TRACE("Failed to open sub key 0x%"PRIxDW"\n", result);
             goto out;
         }
 
         cszOclPath = malloc(dwOclPathSize);
         if (NULL == cszOclPath)
         {
-            KHR_ICD_TRACE("Failed to allocate %lu bytes for registry value\n", dwOclPathSize);
+            KHR_ICD_TRACE("Failed to allocate %"PRIuDW" bytes for registry value\n", dwOclPathSize);
             goto out;
         }
 
@@ -125,7 +125,7 @@ static bool ReadOpenCLKey(DEVINST dnDevNode)
             &dwOclPathSize);
         if (ERROR_SUCCESS != result)
         {
-            KHR_ICD_TRACE("Failed to open sub key 0x%lx\n", result);
+            KHR_ICD_TRACE("Failed to open sub key 0x%"PRIxDW"\n", result);
             goto out;
         }
 
@@ -137,7 +137,7 @@ static bool ReadOpenCLKey(DEVINST dnDevNode)
             }
             else
             {
-                KHR_ICD_TRACE("Unexpected registry entry 0x%lx! continuing\n", dwLibraryNameType);
+                KHR_ICD_TRACE("Unexpected registry entry 0x%"PRIxDW"! continuing\n", dwLibraryNameType);
                 goto out;
             }
         }
@@ -155,7 +155,7 @@ out:
         result = RegCloseKey(hkey);
         if (ERROR_SUCCESS != result)
         {
-            KHR_ICD_TRACE("WARNING: failed to close hkey 0x%lx\n", result);
+            KHR_ICD_TRACE("WARNING: failed to close hkey 0x%"PRIxDW"\n", result);
         }
     }
 
@@ -176,7 +176,7 @@ static DeviceProbeResult ProbeDevice(DEVINST devnode)
 
     if (CR_SUCCESS != ret)
     {
-        KHR_ICD_TRACE("    WARNING: failed to probe the status of the device 0x%lx\n", ret);
+        KHR_ICD_TRACE("    WARNING: failed to probe the status of the device 0x%"PRIxDW"\n", ret);
         return ProbeFailure;
     }
 
@@ -194,7 +194,7 @@ static DeviceProbeResult ProbeDevice(DEVINST devnode)
     if (((ulStatus & DN_HAS_PROBLEM) && ulProblem == CM_PROB_NEED_RESTART) ||
           ulStatus & DN_NEED_RESTART)
     {
-        KHR_ICD_TRACE("    WARNING: device is pending reboot (0x%lx), skipping...\n", ulStatus);
+        KHR_ICD_TRACE("    WARNING: device is pending reboot (0x%" PRIxUL "), skipping...\n", ulStatus);
         return PendingReboot;
     }
 
@@ -239,7 +239,7 @@ bool khrIcdOsVendorsEnumerateHKR(void)
 
         if (CR_SUCCESS != ret)
         {
-            KHR_ICD_TRACE("CM_Get_Device_ID_List_size failed with 0x%lx\n", ret);
+            KHR_ICD_TRACE("CM_Get_Device_ID_List_size failed with 0x%"PRIxDW"\n", ret);
             break;
         }
 
@@ -251,7 +251,7 @@ bool khrIcdOsVendorsEnumerateHKR(void)
         deviceIdList = malloc(szBuffer * sizeof(wchar_t));
         if (NULL == deviceIdList)
         {
-            KHR_ICD_TRACE("Failed to allocate %lu bytes for device ID strings\n", szBuffer);
+            KHR_ICD_TRACE("Failed to allocate %" PRIuUL " bytes for device ID strings\n", szBuffer);
             break;
         }
 
@@ -263,7 +263,7 @@ bool khrIcdOsVendorsEnumerateHKR(void)
 
         if (CR_SUCCESS != ret)
         {
-            KHR_ICD_TRACE("CM_Get_Device_ID_List failed with 0x%lx\n", ret);
+            KHR_ICD_TRACE("CM_Get_Device_ID_List failed with 0x%"PRIxDW"\n", ret);
             KHR_SAFE_RELEASE(deviceIdList);
         }
     } while (CR_BUFFER_SMALL == ret);
@@ -286,7 +286,7 @@ bool khrIcdOsVendorsEnumerateHKR(void)
         }
         else
         {
-            KHR_ICD_TRACE("CM_Locate_DevNode failed with 0x%lx\n", ret);
+            KHR_ICD_TRACE("CM_Locate_DevNode failed with 0x%"PRIxDW"\n", ret);
             continue;
         }
 
@@ -311,7 +311,7 @@ bool khrIcdOsVendorsEnumerateHKR(void)
 
         if (CR_SUCCESS != ret)
         {
-            KHR_ICD_TRACE("    CM_Get_Child returned 0x%lx, skipping children...\n", ret);
+            KHR_ICD_TRACE("    CM_Get_Child returned 0x%"PRIxDW", skipping children...\n", ret);
         }
         else
         {
@@ -330,7 +330,7 @@ bool khrIcdOsVendorsEnumerateHKR(void)
 
                 if (CR_SUCCESS != ret)
                 {
-                    KHR_ICD_TRACE("    CM_Get_Device_ID returned 0x%lx, skipping device...\n", ret);
+                    KHR_ICD_TRACE("    CM_Get_Device_ID returned 0x%"PRIxDW", skipping device...\n", ret);
                     continue;
                 }
                 else


### PR DESCRIPTION
This implements the fix referenced in https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/148
Does this seem to do the trick?